### PR TITLE
merge callback args into EventCtx struct

### DIFF
--- a/wayrs-client/examples/output_info.rs
+++ b/wayrs-client/examples/output_info.rs
@@ -2,8 +2,7 @@ use std::ffi::CString;
 
 use wayrs_client::global::GlobalExt;
 use wayrs_client::protocol::wl_output::{self, WlOutput};
-use wayrs_client::proxy::Proxy;
-use wayrs_client::{Connection, IoMode};
+use wayrs_client::{Connection, EventCtx, IoMode};
 
 fn main() {
     let (mut conn, globals) = Connection::connect_and_collect_globals().unwrap();
@@ -42,19 +41,15 @@ struct OutputInfo {
     mode: Option<String>,
 }
 
-fn wl_output_cb(
-    _: &mut Connection<State>,
-    state: &mut State,
-    output: WlOutput,
-    event: wl_output::Event,
-) {
-    let output = &mut state
+fn wl_output_cb(ctx: EventCtx<State, WlOutput>) {
+    let output = &mut ctx
+        .state
         .outputs
         .iter_mut()
-        .find(|o| o.0.id() == output.id())
+        .find(|o| o.0 == ctx.proxy)
         .unwrap()
         .1;
-    match event {
+    match ctx.event {
         wl_output::Event::Geometry(_) => (),
         wl_output::Event::Mode(mode) => {
             output.mode = Some(format!(

--- a/wayrs-client/examples/output_watcher.rs
+++ b/wayrs-client/examples/output_watcher.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use wayrs_client::global::GlobalExt;
 use wayrs_client::protocol::wl_output::{self, WlOutput};
 use wayrs_client::protocol::wl_registry::{self, GlobalArgs};
-use wayrs_client::{Connection, IoMode};
+use wayrs_client::{Connection, EventCtx, IoMode};
 
 fn main() {
     let mut conn = Connection::connect().unwrap();
@@ -62,18 +62,14 @@ fn wl_registry_cb(conn: &mut Connection<State>, state: &mut State, event: &wl_re
     }
 }
 
-fn wl_output_cb(
-    _: &mut Connection<State>,
-    state: &mut State,
-    output: WlOutput,
-    event: wl_output::Event,
-) {
-    let output = &mut state
+fn wl_output_cb(ctx: EventCtx<State, WlOutput>) {
+    let output = &mut ctx
+        .state
         .outputs
         .iter_mut()
-        .find(|o| o.wl_output == output)
+        .find(|o| o.wl_output == ctx.proxy)
         .unwrap();
-    match event {
+    match ctx.event {
         wl_output::Event::Geometry(_) => (),
         wl_output::Event::Mode(mode) => {
             output.mode = Some(format!(

--- a/wayrs-client/src/global.rs
+++ b/wayrs-client/src/global.rs
@@ -3,7 +3,7 @@ use std::ops;
 
 use crate::protocol::wl_registry::GlobalArgs;
 use crate::proxy::Proxy;
-use crate::Connection;
+use crate::{Connection, EventCtx};
 
 pub type Global = GlobalArgs;
 pub type Globals = [Global];
@@ -39,11 +39,7 @@ pub trait GlobalExt {
     ) -> Result<P, BindError>;
 
     /// Same as [`bind`](Self::bind) but also sets the callback
-    fn bind_with_cb<
-        P: Proxy,
-        D,
-        F: FnMut(&mut Connection<D>, &mut D, P, P::Event) + Send + 'static,
-    >(
+    fn bind_with_cb<P: Proxy, D, F: FnMut(EventCtx<D, P>) + Send + 'static>(
         &self,
         conn: &mut Connection<D>,
         version: impl VersionBounds,
@@ -59,11 +55,7 @@ pub trait GlobalsExt {
     ) -> Result<P, BindError>;
 
     /// Same as [`bind`](Self::bind) but also sets the callback
-    fn bind_with_cb<
-        P: Proxy,
-        D,
-        F: FnMut(&mut Connection<D>, &mut D, P, P::Event) + Send + 'static,
-    >(
+    fn bind_with_cb<P: Proxy, D, F: FnMut(EventCtx<D, P>) + Send + 'static>(
         &self,
         conn: &mut Connection<D>,
         version: impl VersionBounds,
@@ -117,11 +109,7 @@ impl GlobalExt for Global {
     }
 
     /// Same as [`bind`](Self::bind) but also sets the callback
-    fn bind_with_cb<
-        P: Proxy,
-        D,
-        F: FnMut(&mut Connection<D>, &mut D, P, P::Event) + Send + 'static,
-    >(
+    fn bind_with_cb<P: Proxy, D, F: FnMut(EventCtx<D, P>) + Send + 'static>(
         &self,
         conn: &mut Connection<D>,
         version: impl VersionBounds,
@@ -168,11 +156,7 @@ impl GlobalsExt for Globals {
         global.bind(conn, version)
     }
 
-    fn bind_with_cb<
-        P: Proxy,
-        D,
-        F: FnMut(&mut Connection<D>, &mut D, P, P::Event) + Send + 'static,
-    >(
+    fn bind_with_cb<P: Proxy, D, F: FnMut(EventCtx<D, P>) + Send + 'static>(
         &self,
         conn: &mut Connection<D>,
         version: impl VersionBounds,

--- a/wayrs-egl/src/buffer.rs
+++ b/wayrs-egl/src/buffer.rs
@@ -109,12 +109,12 @@ impl Buffer {
 
         let state = Arc::new(Mutex::new(BufferState::Available));
         let state_copy = Arc::clone(&state);
-        conn.set_callback_for(wl_buffer, move |conn, _, wl_buffer, _| {
+        conn.set_callback_for(wl_buffer, move |ctx| {
             let mut state_guard = state_copy.lock().unwrap();
             match *state_guard {
                 BufferState::Available => unreachable!(),
                 BufferState::InUse => *state_guard = BufferState::Available,
-                BufferState::PendingDestruction => wl_buffer.destroy(conn),
+                BufferState::PendingDestruction => ctx.proxy.destroy(ctx.conn),
             }
         });
 

--- a/wayrs-utils/src/shm_alloc.rs
+++ b/wayrs-utils/src/shm_alloc.rs
@@ -120,9 +120,9 @@ impl Buffer {
             self.spec.height as i32,
             self.spec.stride as i32,
             self.spec.format,
-            move |conn, _state, wl_buffer, _released_event| {
+            move |ctx| {
                 assert!(refcnt.fetch_sub(1, Ordering::AcqRel) > 0);
-                wl_buffer.destroy(conn);
+                ctx.proxy.destroy(ctx.conn);
             },
         )
     }
@@ -183,7 +183,7 @@ impl InitShmPool {
                 spec.height as i32,
                 spec.stride as i32,
                 spec.format,
-                move |_conn, _state, _wl_buffer, _released_event| {
+                move |_| {
                     assert!(seg_refcnt.fetch_sub(1, Ordering::SeqCst) > 0);
                     // We don't destroy the buffer here because it can be reused later
                 },


### PR DESCRIPTION
### Before

```rust
fn wl_output_cb(
    conn: &mut Connection<State>,
    state: &mut State,
    output: WlOutput,
    event: wl_output::Event,
) {
    todo!();
}
```

### After

```rust
fn wl_output_cb(ctx: EventCtx<State, WlOutput>) {
    todo!();
}
```

This is obviously a breaking change and migrating is a bit annoying, but there are several advantages:

- Shorter code.
- No need to specify the event type (it is derived from proxy type).
- `EventCtx` is `#[non_exhaustive]` - supplying more information to callbacks will not be a breaking change in the future.