### PR TITLE
client: make Conneccion transport-agonistic

### DIFF
--- a/wayrs-client/Cargo.toml
+++ b/wayrs-client/Cargo.toml
@@ -10,6 +10,13 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+any_transport = []
+
+[[example]]
+name = "custom_transport"
+required-features = ["any_transport"]
+
 [dependencies]
 wayrs-core = { version = "1.0", path = "../wayrs-core" }
 wayrs-scanner = { version = "0.15.2", path = "../wayrs-scanner" }

--- a/wayrs-client/examples/custom_transport.rs
+++ b/wayrs-client/examples/custom_transport.rs
@@ -1,0 +1,86 @@
+//! An example of how to use your own custom transport implementation.
+//! Here, the transport keeps track of how much bytes were sent/received.
+
+use std::collections::VecDeque;
+use std::env;
+use std::io;
+use std::os::fd::{OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+use wayrs_client::core::transport::Transport;
+use wayrs_client::protocol::wl_registry;
+use wayrs_client::{Connection, IoMode};
+
+fn main() {
+    let mut conn = Connection::with_transport(MyTransport::connect());
+
+    conn.add_registry_cb(|_conn, _state, event| match event {
+        wl_registry::Event::Global(g) => println!(
+            "global ({}) {} added",
+            g.name,
+            g.interface.to_string_lossy(),
+        ),
+        wl_registry::Event::GlobalRemove(name) => println!("global ({name}) removed"),
+    });
+
+    loop {
+        conn.flush(IoMode::Blocking).unwrap();
+        conn.recv_events(IoMode::Blocking).unwrap();
+        conn.dispatch_events(&mut ());
+
+        let t = conn.transport::<MyTransport>().unwrap();
+        eprintln!("up: {}b down: {}b", t.bytes_sent, t.bytes_read);
+    }
+}
+
+struct MyTransport {
+    socket: UnixStream,
+    bytes_read: usize,
+    bytes_sent: usize,
+}
+
+impl Transport for MyTransport {
+    fn pollable_fd(&self) -> RawFd {
+        self.socket.pollable_fd()
+    }
+
+    fn send(
+        &mut self,
+        bytes: &[std::io::IoSlice],
+        fds: &[OwnedFd],
+        mode: IoMode,
+    ) -> io::Result<usize> {
+        let n = self.socket.send(bytes, fds, mode)?;
+        self.bytes_sent += n;
+        Ok(n)
+    }
+
+    fn recv(
+        &mut self,
+        bytes: &mut [std::io::IoSliceMut],
+        fds: &mut VecDeque<OwnedFd>,
+        mode: IoMode,
+    ) -> io::Result<usize> {
+        let n = self.socket.recv(bytes, fds, mode)?;
+        self.bytes_read += n;
+        Ok(n)
+    }
+}
+
+impl MyTransport {
+    fn connect() -> Self {
+        let runtime_dir = env::var_os("XDG_RUNTIME_DIR").unwrap();
+        let wayland_disp = env::var_os("WAYLAND_DISPLAY").unwrap();
+
+        let mut path = PathBuf::new();
+        path.push(runtime_dir);
+        path.push(wayland_disp);
+
+        Self {
+            socket: UnixStream::connect(path).unwrap(),
+            bytes_read: 0,
+            bytes_sent: 0,
+        }
+    }
+}

--- a/wayrs-client/src/any_transport.rs
+++ b/wayrs-client/src/any_transport.rs
@@ -1,0 +1,59 @@
+use std::any::Any;
+use std::collections::VecDeque;
+use std::io;
+use std::os::fd::{OwnedFd, RawFd};
+
+use wayrs_core::transport::Transport;
+use wayrs_core::IoMode;
+
+pub struct AnyTranpsort(Box<dyn AnyTransportImp>);
+
+impl AnyTranpsort {
+    pub fn new<T>(transport: T) -> Self
+    where
+        T: Transport + Send + 'static,
+    {
+        Self(Box::new(transport))
+    }
+
+    pub fn as_any(&self) -> &dyn Any {
+        self.0.as_any()
+    }
+
+    pub fn as_any_mut(&mut self) -> &mut dyn Any {
+        self.0.as_any_mut()
+    }
+}
+
+trait AnyTransportImp: Transport + Send {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Transport + Send + 'static> AnyTransportImp for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Transport for AnyTranpsort {
+    fn pollable_fd(&self) -> RawFd {
+        self.0.as_ref().pollable_fd()
+    }
+
+    fn send(&mut self, bytes: &[io::IoSlice], fds: &[OwnedFd], mode: IoMode) -> io::Result<usize> {
+        self.0.as_mut().send(bytes, fds, mode)
+    }
+
+    fn recv(
+        &mut self,
+        bytes: &mut [io::IoSliceMut],
+        fds: &mut VecDeque<OwnedFd>,
+        mode: IoMode,
+    ) -> io::Result<usize> {
+        self.0.as_mut().recv(bytes, fds, mode)
+    }
+}

--- a/wayrs-client/src/lib.rs
+++ b/wayrs-client/src/lib.rs
@@ -9,6 +9,9 @@ pub mod protocol;
 mod connection;
 mod debug_message;
 
+#[cfg(feature = "any_transport")]
+mod any_transport;
+
 pub use connection::{ConnectError, Connection};
 
 #[doc(hidden)]


### PR DESCRIPTION
Alternative to #10 and #16.

Use

```rust
let conn = Connection::with_transport(...);
```

to create a connection based on a custom transport.