### PR TITLE
Add #[must_use] to functions without side-effects

### DIFF
--- a/wayrs-client/src/connection.rs
+++ b/wayrs-client/src/connection.rs
@@ -164,6 +164,7 @@ impl<D> Connection<D> {
     ///
     /// At the moment, only a single registry can be created. This might or might not change in the
     /// future, considering registries cannot be destroyed.
+    #[must_use]
     pub fn registry(&self) -> WlRegistry {
         self.registry
     }
@@ -174,6 +175,7 @@ impl<D> Connection<D> {
     ///
     /// Note that this function has knowledge of all events received from the compositor, even the
     /// ones that had not been dispatched in [`dispatch_events`](Self::dispatch_events) yet.
+    #[must_use]
     pub fn globals(&self) -> &[GlobalArgs] {
         &self.globals
     }
@@ -297,6 +299,7 @@ impl<D> Connection<D> {
     /// Remove all callbacks.
     ///
     /// You can use this function to change the "state type" of a connection.
+    #[must_use]
     pub fn clear_callbacks<D2>(self) -> Connection<D2> {
         Connection {
             #[cfg(feature = "tokio")]

--- a/wayrs-core/src/lib.rs
+++ b/wayrs-core/src/lib.rs
@@ -41,16 +41,19 @@ impl ObjectId {
     pub const MIN_SERVER: Self = Self(unsafe { NonZeroU32::new_unchecked(0xFF000000) });
 
     /// Returns the numeric representation of the ID
+    #[must_use]
     pub fn as_u32(self) -> u32 {
         self.0.get()
     }
 
     /// Whether the object with this ID was created by the server
+    #[must_use]
     pub fn created_by_server(self) -> bool {
         self >= Self::MIN_SERVER
     }
 
     /// Whether the object with this ID was created by the client
+    #[must_use]
     pub fn created_by_client(self) -> bool {
         self <= Self::MAX_CLIENT
     }
@@ -111,6 +114,7 @@ pub enum ArgValue {
 
 impl ArgValue {
     /// The size of the argument in bytes.
+    #[must_use]
     pub fn size(&self) -> usize {
         match self {
             Self::Int(_)
@@ -165,18 +169,22 @@ impl Fixed {
     pub const ONE: Self = Self(256);
     pub const MINUS_ONE: Self = Self(-256);
 
+    #[must_use]
     pub fn as_f64(self) -> f64 {
         self.0 as f64 / 256.0
     }
 
+    #[must_use]
     pub fn as_f32(self) -> f32 {
         self.0 as f32 / 256.0
     }
 
+    #[must_use]
     pub fn as_int(self) -> i32 {
         self.0 / 256
     }
 
+    #[must_use]
     pub fn is_int(self) -> bool {
         self.0 & 255 == 0
     }

--- a/wayrs-egl/src/buffer.rs
+++ b/wayrs-egl/src/buffer.rs
@@ -133,26 +133,31 @@ impl Buffer {
     }
 
     /// Get this buffer's fourcc format
+    #[must_use]
     pub fn fourcc(&self) -> Fourcc {
         self.fourcc
     }
 
     /// Get this buffer format's modifier
+    #[must_use]
     pub fn modifier(&self) -> u64 {
         self.modifier
     }
 
     /// Get this buffer's width
+    #[must_use]
     pub fn width(&self) -> u32 {
         self.width
     }
 
     /// Get this buffer's height
+    #[must_use]
     pub fn height(&self) -> u32 {
         self.height
     }
 
     /// Check whether this buffer is currently in use by the compositor.
+    #[must_use]
     pub fn is_available(&self) -> bool {
         *self.state.lock().unwrap() == BufferState::Available
     }
@@ -228,6 +233,7 @@ pub struct BufferPool<const N: usize> {
 
 impl<const N: usize> BufferPool<N> {
     /// Create a new buffer pool.
+    #[must_use]
     pub fn new(fourcc: Fourcc, modifiers: Vec<u64>) -> Self {
         Self {
             fourcc,

--- a/wayrs-egl/src/drm.rs
+++ b/wayrs-egl/src/drm.rs
@@ -27,6 +27,7 @@ impl DrmDevice {
     }
 
     /// Get a render node path, if supported.
+    #[must_use]
     pub fn render_node(&self) -> Option<&CStr> {
         self.get_node(xf86drm_ffi::DRM_NODE_RENDER)
     }

--- a/wayrs-egl/src/egl.rs
+++ b/wayrs-egl/src/egl.rs
@@ -117,39 +117,47 @@ impl EglDisplay {
         })
     }
 
+    #[must_use]
     pub(crate) fn as_raw(&self) -> egl_ffi::EGLDisplay {
         self.raw
     }
 
+    #[must_use]
     pub(crate) fn gbm_device(&self) -> &gbm::Device {
         &self.gbm_device
     }
 
+    #[must_use]
     pub(crate) fn linux_dmabuf(&self) -> ZwpLinuxDmabufV1 {
         self.linux_dmabuf
     }
 
     /// Major EGL version
+    #[must_use]
     pub fn major_version(&self) -> u32 {
         self.major_version
     }
 
     /// Minor EGL version
+    #[must_use]
     pub fn minor_version(&self) -> u32 {
         self.minor_version
     }
 
     /// The set of extensions this EGL display supports
+    #[must_use]
     pub fn extensions(&self) -> &EglExtensions {
         &self.extensions
     }
 
     /// Get a set of supported buffer formats, in a form of fourcc -> modifiers mapping
+    #[must_use]
     pub fn supported_formats(&self) -> &HashMap<Fourcc, Vec<u64>> {
         &self.supported_formats
     }
 
     /// Check whether a fourcc/modifier pair is supported
+    #[must_use]
     pub fn is_format_supported(&self, fourcc: Fourcc, modifier: u64) -> bool {
         match self.supported_formats.get(&fourcc) {
             Some(mods) => {
@@ -262,6 +270,7 @@ pub struct EglContextBuilder {
 
 impl EglContextBuilder {
     /// Create a new [`EglContext`] builder
+    #[must_use]
     pub fn new(api: GraphicsApi) -> Self {
         Self {
             api,
@@ -272,6 +281,7 @@ impl EglContextBuilder {
     }
 
     /// Set the required API version. Default is `1.0`.
+    #[must_use]
     pub fn version(mut self, major: u32, minor: u32) -> Self {
         self.major_v = major;
         self.minor_v = minor;
@@ -281,6 +291,7 @@ impl EglContextBuilder {
     /// Enable/disable debugging. Default is `false`.
     ///
     /// Ignored if EGL version is lower than 1.5.
+    #[must_use]
     pub fn debug(mut self, enable: bool) -> Self {
         self.debug = enable;
         self
@@ -421,6 +432,7 @@ impl EglExtensions {
     }
 
     /// Check whether a given extension is supported
+    #[must_use]
     pub fn contains(&self, ext: &str) -> bool {
         self.0.contains(ext.as_bytes())
     }

--- a/wayrs-egl/src/errors.rs
+++ b/wayrs-egl/src/errors.rs
@@ -107,6 +107,7 @@ impl fmt::Display for EglError {
 }
 
 impl EglError {
+    #[must_use]
     pub fn last() -> Self {
         match unsafe { egl_ffi::eglGetError() } {
             egl_ffi::EGL_SUCCESS => Self::Success,
@@ -130,6 +131,7 @@ impl EglError {
 }
 
 impl Error {
+    #[must_use]
     pub fn last_egl() -> Self {
         Self::Egl(EglError::last())
     }

--- a/wayrs-utils/src/dmabuf_feedback.rs
+++ b/wayrs-utils/src/dmabuf_feedback.rs
@@ -79,14 +79,17 @@ impl DmabufFeedback {
         }
     }
 
+    #[must_use]
     pub fn wl(&self) -> ZwpLinuxDmabufFeedbackV1 {
         self.wl
     }
 
+    #[must_use]
     pub fn main_device(&self) -> Option<dev_t> {
         self.main_device
     }
 
+    #[must_use]
     pub fn format_table(&self) -> &[FormatTableEntry] {
         match &self.format_table {
             Some(mmap) => unsafe {
@@ -99,6 +102,7 @@ impl DmabufFeedback {
         }
     }
 
+    #[must_use]
     pub fn tranches(&self) -> &[DmabufTranche] {
         &self.tranches
     }

--- a/wayrs-utils/src/timer.rs
+++ b/wayrs-utils/src/timer.rs
@@ -9,6 +9,7 @@ pub struct Timer {
 
 impl Timer {
     /// Create a new timer with a given delay and interval.
+    #[must_use]
     pub fn new(delay: Duration, interval: Duration) -> Self {
         Self {
             next_fire: Instant::now() + delay,
@@ -32,6 +33,7 @@ impl Timer {
     }
 
     /// The duration untill next fire.
+    #[must_use]
     pub fn sleep(&self) -> Duration {
         self.next_fire.saturating_duration_since(Instant::now())
     }


### PR DESCRIPTION
Add #[must_use] to all functions that return a value without any side effect. This results in user code getting a lint if the accidentally call one of these functions but don't use the return value in any way.